### PR TITLE
spotifyd-client-1 - Fix running SpotifyD through addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The installation process for the plugin is relatively simple, but requires a bit
 
 Follow [the SpotifyD source compilation steps](https://spotifyd.github.io/spotifyd/installation/index.html) on your target machine. If you know how to cross-compile for different hardware, feel free to follow [the cross-compilation steps](https://github.com/Spotifyd/spotifyd/wiki/Cross-Compiling-on-Ubuntu) instead.
 
-Be aware that most installations default to the ALSA audio backend which only supports one program taking over an audio output device at a time. Other audio backends like pulseaudio and rodio fix this. Make sure you compile SpotifyD with the optional feature flag for your preferred audio backend. Rodio should work for most installations.
+Be aware that most installations default to the ALSA audio backend which only supports one program taking over an audio output device at a time. Other audio backends like pulseaudio and rodio fix this. Make sure you compile SpotifyD with the optional feature flag for your preferred audio backend. Rodio should work for most installations. **Note that if you are using the Pulseaudio or Rodio audio backend, there are some lines that need to be uncommented in your SpotifyD configuration file!**
 
 ### Spotify Developer
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The installation process for the plugin is relatively simple, but requires a bit
 
 Follow [the SpotifyD source compilation steps](https://spotifyd.github.io/spotifyd/installation/index.html) on your target machine. If you know how to cross-compile for different hardware, feel free to follow [the cross-compilation steps](https://github.com/Spotifyd/spotifyd/wiki/Cross-Compiling-on-Ubuntu) instead.
 
+Be aware that most installations default to the ALSA audio backend which only supports one program taking over an audio output device at a time. Other audio backends like pulseaudio and rodio fix this. Make sure you compile SpotifyD with the optional feature flag for your preferred audio backend. Rodio should work for most installations.
+
 ### Spotify Developer
 
 In order to get the functionalities of the app to work, you need a Spotify Developer account and an app registered in the Spotify Developer dashboard.

--- a/addon.py
+++ b/addon.py
@@ -10,6 +10,8 @@ SPOTIFYD_LOG_READ_LINE_AMOUNT = 100
 SPOTIFY_API_URL_TOKEN = 'https://accounts.spotify.com/api/token'
 SPOTIFY_API_URL_TRACK = 'https://api.spotify.com/v1/tracks/'
 THREAD_LIST_FILE_PATH = '/tmp/runningproc.cfg'
+TMP_PATH = '/tmp/spotifyd-client/'
+ALBUM_ART_PATH = f'{TMP_PATH}albumArt/'
 LIGHTNESS_PIXEL_LOCATIONS = [(0.5, 0.5), (0.5, 0.75), (0.35, 0.65), (0.65, 0.65)]
 
 currSong = '<song>'
@@ -103,8 +105,7 @@ def getTrackData(lastTrackId, accessToken, accessTokenExpire):
     }
 
 def getTrackId():
-    addonPath = service.getAddonPath()
-    f = open(f'{addonPath}songs.log', 'r', -1, 'utf-8')
+    f = open(f'{TMP_PATH}songs.log', 'r', -1, 'utf-8')
     songLog = f.read().splitlines()
     f.close()
     songLog = [k for k in songLog if '"PLAYER_EVENT": "play"' in k]
@@ -115,15 +116,15 @@ def getTrackId():
     return songLine[x+13:x+13+22]
 
 def updateAlbumArt(lastTrackId, currTrackId, images):
-    addonPath = service.getAddonPath()
-    lastTrackPath = f'{addonPath}albumArt/{lastTrackId}'
-    currTrackPath = f'{addonPath}albumArt/{currTrackId}'
+    lastTrackPath = f'{ALBUM_ART_PATH}{lastTrackId}'
+    currTrackPath = f'{ALBUM_ART_PATH}{currTrackId}'
 
     if lastTrackId == currTrackId:
         return lastTrackPath
 
-    os.system(f'rm {addonPath}albumArt/*')
-    
+    os.system(f'rm -r {ALBUM_ART_PATH}')
+    os.system(f'mkdir {ALBUM_ART_PATH}')
+
     images = sorted(images, key=lambda d: d['width'], reverse=False)
 
     #HQ

--- a/resources/spotifyd.conf
+++ b/resources/spotifyd.conf
@@ -1,10 +1,15 @@
 [global]
+# Uncomment / edit the lines below if using rodio or pulseaudio backend
+#use_mpris = false
+#backend = "rodio"/"pulseaudio" #<-- pick one, remove the other
+#volume_controller = "softvol"
+
 # A command that gets executed in your shell after each song changes.
 on_song_change_hook = "echo 1 > /tmp/songChange.tmp"
 
 # The name that gets displayed under the connect tab on
 # official clients. Spaces are not allowed!
-device_name = "JeroenMediaServer"
+device_name = "SpotifydClient"
 
 # If set to true, enables volume normalisation between songs.
 volume_normalisation = true

--- a/runner.py
+++ b/runner.py
@@ -1,6 +1,7 @@
-import os, subprocess
+import xbmcaddon
+import subprocess
 
-addonPath = os.path.dirname(os.path.realpath(__file__))
+addonPath = xbmcaddon.Addon().getAddonInfo('path')
 
 fstd = open(f"/tmp/spotifyd-client/songs.log", "w")
 ferr = open(f"/tmp/spotifyd-client/error.log", "w")

--- a/runner.py
+++ b/runner.py
@@ -1,8 +1,0 @@
-import xbmcaddon
-import subprocess
-
-addonPath = xbmcaddon.Addon().getAddonInfo('path')
-
-fstd = open(f"/tmp/spotifyd-client/songs.log", "w")
-ferr = open(f"/tmp/spotifyd-client/error.log", "w")
-subprocess.Popen([f"{addonPath}/resources/lib/spotifyd/spotifyd --no-daemon --config-path {addonPath}/resources/spotifyd.conf"])

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,7 @@
+import os, subprocess
+
+addonPath = os.path.dirname(os.path.realpath(__file__))
+
+fstd = open(f"/tmp/spotifyd-client/songs.log", "w")
+ferr = open(f"/tmp/spotifyd-client/error.log", "w")
+subprocess.Popen([f"{addonPath}/resources/lib/spotifyd/spotifyd --no-daemon --config-path {addonPath}/resources/spotifyd.conf"])

--- a/service.py
+++ b/service.py
@@ -1,4 +1,4 @@
-import xbmcaddon
+import xbmc, xbmcaddon
 import subprocess, os
 
 addon = xbmcaddon.Addon()
@@ -10,9 +10,7 @@ def getAddonPath():
     return addonPath
 
 def startUp():
-    f = open(f"{addonPath}songs.log", "w")
-    f.truncate()
-    subprocess.Popen([f'{spotifyPath} --no-daemon --config-path {addonPath}resources/spotifyd.conf'], shell=True, stdout=f)
+    xbmc.executebuiltin(f'RunScript("{addonPath}runner.py")')
 
 def shutDown():
     subprocess.run(["kill", "$(ps | grep spotify | awk '{print $1}')"], shell=True, stdin=None, stdout=None, stderr=None, close_fds=True)

--- a/service.py
+++ b/service.py
@@ -10,7 +10,11 @@ def getAddonPath():
     return addonPath
 
 def startUp():
-    xbmc.executebuiltin(f'RunScript("{addonPath}runner.py")')
+    if not os.path.exists("/tmp/spotifyd-client"):
+        os.makedirs("/tmp/spotifyd-client")
+    fstd = open("/tmp/spotifyd-client/songs.log", "w")
+    ferr = open("/tmp/spotifyd-client/error.log", "w")
+    subprocess.Popen([f"{addonPath}/resources/lib/spotifyd/spotifyd --no-daemon --config-path {addonPath}/resources/spotifyd.conf"], stdout=fstd, stderr=ferr)
 
 def shutDown():
     subprocess.run(["kill", "$(ps | grep spotify | awk '{print $1}')"], shell=True, stdin=None, stdout=None, stderr=None, close_fds=True)


### PR DESCRIPTION
Fixes #1.

Note: in #1 a mention was made of OSMC. By default, OSMC (and many other kodi installations) uses the ALSA audio backend. In order to get SpotifyD running you should compile it with the rodio backend (or other preferred audio backend if available).

A precompiled binary for SpotifyD for ARMv7x64 machines (such as the Vero 4K(+) and the Raspberry Pi 4b) with the optional rodio audio backend is available [here](https://www.mediafire.com/file/zw8a1s44d7cvezc/spotifyd_armv7.tar/file).